### PR TITLE
21.0.1

### DIFF
--- a/main
+++ b/main
@@ -19,7 +19,7 @@ EOF
 
 #source bids_funcs.sh
 
-=======
+#=======
 WORKDIRNAME=work
 if [ -d "/scratch/$USER/job_$SLURM_JOB_ID" ]; then
     echo "using NVMe directory"
@@ -95,6 +95,9 @@ if [[ $inFSDIR != "null" ]] ; then
     sub=$(jq -r '._inputs[] | select(.id == "t1w") | .meta.subject' config.json)
     cp -rH $inFSDIR $outdir/freesurfer/sub-$sub
     chmod -R +rw $outdir/freesurfer
+    fs_dir_line='--fs_subjects_dir=$outdir/freesurfer'
+else
+    fs_dir_line=''
 fi
 
 # avoid templateflow problems on HPC's running singularity
@@ -124,6 +127,7 @@ time singularity exec -e \
     --use-syn-sdc \
     $aroma \
     $skipbidsvalidation \
+    $fs_dir_line \
     --skull-strip-template=NKI \
     --work-dir=$WORKDIRNAME \
     --fs-license-file=license.txt \

--- a/main
+++ b/main
@@ -95,7 +95,7 @@ if [[ $inFSDIR != "null" ]] ; then
     sub=$(jq -r '._inputs[] | select(.id == "t1w") | .meta.subject' config.json)
     cp -rH $inFSDIR $outdir/freesurfer/sub-$sub
     chmod -R +rw $outdir/freesurfer
-    fs_dir_line='--fs_subjects_dir=$outdir/freesurfer'
+    fs_dir_line=$(eval "echo --fs_subjects_dir \${outdir}/freesurfer")
 else
     fs_dir_line=''
 fi

--- a/main
+++ b/main
@@ -95,7 +95,7 @@ if [[ $inFSDIR != "null" ]] ; then
     sub=$(jq -r '._inputs[] | select(.id == "t1w") | .meta.subject' config.json)
     cp -rH $inFSDIR $outdir/freesurfer/sub-$sub
     chmod -R +rw $outdir/freesurfer
-    fs_dir_line=$(eval "echo --fs_subjects_dir \${outdir}/freesurfer")
+    fs_dir_line=$(eval "echo --fs-subjects-dir \${outdir}/freesurfer")
 else
     fs_dir_line=''
 fi


### PR DESCRIPTION
fMRIPrep v 21.x.x made a change to some of the default behavior of the variables, causing fMRIPrep to look in the incorrect location for a precomputed freesurfer.

To correct this, this PR will add a new line to the fmriprep call (--fs-subjects-dir) pointing fMRIPrep to the correct location if a precomputed Freesurfer was inputted. I believe this will allow for future proofing.