### PR TITLE
Fixed the error to where the tsv files does get removed during fMRI prep

### DIFF
--- a/fmriprep2bl.sh
+++ b/fmriprep2bl.sh
@@ -97,12 +97,12 @@ mv output_report/fmriprep output_report/html
 mkdir -p parcellation
 labelsTsv=$outdir/fmriprep/desc-aparcaseg_dseg.tsv
 cp ${labelsTsv} ./labels.tsv
-oDir=$outdir/fmriprep/sub-$sub
+#oDir=$outdir/fmriprep/sub-$sub
 ln -sf ../$(find $oDir/anat -name "*_desc-aparcaseg_dseg.nii.gz" -not -name "*space*") parcellation/parc.nii.gz
 
 ### transform/h5 datatype
 mkdir -p transform
-oDir=$outdir/fmriprep/sub-$sub
+#oDir=$outdir/fmriprep/sub-$sub
 ln -sf ../$(find $oDir/anat -name "*_from-T1w_to-${space}_mode-image_xfm.h5") transform/warp.h5
 ln -sf ../$(find $oDir/anat -name "*_from-${space}_to-T1w_mode-image_xfm.h5") transform/inverse-warp.h5
 ln -sf ../$(find $oDir/anat -name "*_from-T1w_to-*mode-image_xfm.txt") transform/affine.txt

--- a/fmriprep2bl.sh
+++ b/fmriprep2bl.sh
@@ -103,6 +103,9 @@ ln -sf ../$(find $oDir/anat -name "*_desc-aparcaseg_dseg.nii.gz" -not -name "*sp
 ### transform/h5 datatype
 mkdir -p transform
 #oDir=$outdir/fmriprep/sub-$sub
+if [[ ${space} == 'T1w' ]]; then
+    space="fsnative"
+fi
 ln -sf ../$(find $oDir/anat -name "*_from-T1w_to-${space}_mode-image_xfm.h5") transform/warp.h5
 ln -sf ../$(find $oDir/anat -name "*_from-${space}_to-T1w_mode-image_xfm.h5") transform/inverse-warp.h5
 ln -sf ../$(find $oDir/anat -name "*_from-T1w_to-*mode-image_xfm.txt") transform/affine.txt

--- a/fmriprep2bl.sh
+++ b/fmriprep2bl.sh
@@ -104,7 +104,7 @@ ln -sf ../$(find $oDir/anat -name "*_desc-aparcaseg_dseg.nii.gz" -not -name "*sp
 mkdir -p transform
 #oDir=$outdir/fmriprep/sub-$sub
 if [[ ${space} == 'T1w' ]]; then
-    space="fsnative"
+    space="MNI152NLin6Asym"
 fi
 ln -sf ../$(find $oDir/anat -name "*_from-T1w_to-${space}_mode-image_xfm.h5") transform/warp.h5
 ln -sf ../$(find $oDir/anat -name "*_from-${space}_to-T1w_mode-image_xfm.h5") transform/inverse-warp.h5

--- a/fmriprep2bl.sh
+++ b/fmriprep2bl.sh
@@ -56,6 +56,10 @@ else # else its a volume(bold) output
     #sub-A00008326_ses-DS2_task-rest_acq-645_space-MNI152NLin6Asym_res-2_desc-preproc_bold.nii.gz
     ln -sf ../$(find $oDir/func -name "*_space-${space}_*desc-preproc_bold.nii.gz") bold_img/bold.nii.gz
 
+    # get the events.tsv file
+    EVENTS=`jq -r '.events' config.json`
+    ln -sf $EVENTS bold_img/events.tsv
+
     # get the preproc fmri volmask
     mkdir -p bold_mask
     ln -sf ../$(find $oDir/func -name "*_space-${space}_*desc-brain_mask.nii.gz") bold_mask/mask.nii.gz

--- a/main
+++ b/main
@@ -126,8 +126,9 @@ echo "done with fmriprep! - now organizing output"
 ./fmriprep2bl.sh
 
 #for debugging https://github.com/nipreps/fmriprep/issues/2070
-#rm -r $WORKDIRNAME # save lots of space
-cp -r $WORKDIRNAME debug
+#cp -r $WORKDIRNAME debug
+
+rm -r $WORKDIRNAME #saves scratch space/inodes
 
 echo "all done"
 

--- a/main
+++ b/main
@@ -102,8 +102,7 @@ rm -rf $WORKDIRNAME && mkdir -p $WORKDIRNAME
 
 # TODO - I shouldn't set cifti-output if it's running in volume mode?
 time singularity exec -e \
-    docker://nipreps/fmriprep:20.2.3 \
-    /usr/local/miniconda/bin/fmriprep \
+    docker://nipreps/fmriprep:21.0.1 fmriprep \
     --notrack \
     --resource-monitor \
     --md-only-boilerplate \

--- a/main
+++ b/main
@@ -125,7 +125,9 @@ time singularity exec -e \
 echo "done with fmriprep! - now organizing output"
 ./fmriprep2bl.sh
 
-rm -r $WORKDIRNAME # save lots of space
+#for debugging https://github.com/nipreps/fmriprep/issues/2070
+#rm -r $WORKDIRNAME # save lots of space
+cp -r $WORKDIRNAME debug
 
 echo "all done"
 

--- a/main
+++ b/main
@@ -25,7 +25,8 @@ outdir=out
 #admin told me that it's causing high IOP
 WORKDIRNAME=work
 if [ -d "/scratch/$USER/job_$SLURM_JOB_ID" ]; then
-    WORKDIRNAME-/scratch/$USER/job_$SLURM_JOB_ID/work
+    echo "using NVMe directory"
+    WORKDIRNAME=/scratch/$USER/job_$SLURM_JOB_ID/work
 fi
 
 inT1w=`jq -r '.t1' config.json`

--- a/main
+++ b/main
@@ -124,7 +124,7 @@ time singularity exec -e \
     --omp-nthreads 16 \
     --nthreads 16 \
     --force-bbr \
-    --use-syn-sdc \
+    --use-syn-sdc warn \
     $aroma \
     $skipbidsvalidation \
     $fs_dir_line \


### PR DESCRIPTION
I made a mistake while writing the commit message but this code should resolve the issue of the events.tsv file being dropped during fMRIprep

(Special Thanks to @anibalsolon for the guidance)